### PR TITLE
Set image src if no token is provided

### DIFF
--- a/d2l-image.html
+++ b/d2l-image.html
@@ -47,6 +47,8 @@
 					Authorization: 'Bearer ' + this.token
 				};
 				this.$.imageRequest.generateRequest();
+			} else {
+				this.$.image.src = this.imageUrl;
 			}
 		},
 


### PR DESCRIPTION
If no token is provided, simply set the `src` attribute of the `img` tag

required: https://github.com/Brightspace/user-tile/pull/19