### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Brightspace/Intrepid
+* @Brightspace/Voyager


### PR DESCRIPTION
Aside: only used by `@d2l/user-tile` (which is only used by `folio-app`!), so all these repos could roll into `folio-app` or `folio-components`.