### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "devDependencies": {
     "@babel/core": "^7",
     "@babel/eslint-parser": "^7",


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564